### PR TITLE
fix(operator): panic on go.mod go.sum search

### DIFF
--- a/install/operator/pkg/build/pkg.go
+++ b/install/operator/pkg/build/pkg.go
@@ -2,11 +2,6 @@ package build
 
 import (
 	"os"
-	"path/filepath"
-)
-
-var (
-	GO_MOD_DIRECTORY string
 )
 
 func FileExists(name string) bool {
@@ -17,31 +12,4 @@ func FileExists(name string) bool {
 		}
 	}
 	return !stat.IsDir()
-}
-
-func init() {
-
-	// Save the original directory the process started in.
-	wd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	initialDir, err := filepath.Abs(wd)
-	if err != nil {
-		panic(err)
-	}
-
-	// Find the module dir..
-	current := ""
-	for next := initialDir; current != next; next = filepath.Dir(current) {
-		current = next
-		if FileExists(filepath.Join(current, "go.mod")) && FileExists(filepath.Join(current, "go.sum")) {
-			GO_MOD_DIRECTORY = current
-			break
-		}
-	}
-
-	if GO_MOD_DIRECTORY == "" {
-		panic("could not find the root module directory")
-	}
 }

--- a/install/operator/pkg/generator/dev/dev.go
+++ b/install/operator/pkg/generator/dev/dev.go
@@ -1,18 +1,16 @@
 package dev
 
 import (
-	"github.com/shurcooL/httpfs/filter"
-	"github.com/syndesisio/syndesis/install/operator/pkg/build"
-	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/shurcooL/httpfs/filter"
+	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 )
 
 func GetAssetsFS() http.FileSystem {
-	assetsDir := filepath.Join(build.GO_MOD_DIRECTORY, "pkg", "generator", "assets")
-	return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
+	return util.NewFileInfoMappingFS(filter.Keep(http.Dir("assets"), func(path string, fi os.FileInfo) bool {
 		if fi.Name() == ".DS_Store" {
 			return false
 		}

--- a/install/operator/pkg/syndesis/olm/assets.go
+++ b/install/operator/pkg/syndesis/olm/assets.go
@@ -28,12 +28,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/httpfs/filter"
-	"github.com/syndesisio/syndesis/install/operator/pkg/build"
 	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 )
 
 func GetAssetsFS() http.FileSystem {
-	assetsDir := filepath.Join(build.GO_MOD_DIRECTORY, "pkg", "syndesis", "olm", "assets")
+	assetsDir := filepath.Join("assets")
 	return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
 		if fi.Name() == "assets_generate.go" {
 			return false


### PR DESCRIPTION
The `init` function in `pkg/build/pkg.go` relies on having the project
sources checked out by tring to locate `go.mod` or `go.sum` files. These
are not present when the binary is run outside of the source tree.

The lookup is used to determine the correct path to the resource asset
files.

We can rely on the behaviour of golang tooling to set the working
directory when build/code generation is run, and use relative paths
instead. This eliminates the need to have the `init` function.